### PR TITLE
Add alternative dependency gir1.2-ayatanaappindicator3-0.1.

### DIFF
--- a/gcdemu/debian/control
+++ b/gcdemu/debian/control
@@ -12,7 +12,7 @@ Standards-Version: 4.3.0
 Package: gcdemu
 Architecture: all
 Depends: python3 (>= 3.4.0), python3-gi (>= 3.0.0), gir1.2-glib-2.0,
- gir1.2-gtk-3.0, gir1.2-appindicator3-0.1, gir1.2-notify-0.7,
+ gir1.2-gtk-3.0, gir1.2-appindicator3-0.1 | gir1.2-ayatanaappindicator3-0.1, gir1.2-notify-0.7,
  cdemu-daemon (>= 3.0.0), librsvg2-2, ${python3:Depends}, ${misc:Depends}
 Recommends: cdemu-client (>= 3.0.0)
 Description: GNOME application to control CDEmu daemon

--- a/gcdemu/src/gcdemu
+++ b/gcdemu/src/gcdemu
@@ -52,7 +52,13 @@ try:
     from gi.repository import AppIndicator3 as AppIndicator
     have_app_indicator = True
 except:
-    have_app_indicator = False
+    try:
+        gi.require_version('AyatanaAppIndicator3', '0.1')
+
+        from gi.repository import AyatanaAppIndicator3 as AppIndicator
+        have_app_indicator = True
+    except:
+        have_app_indicator = False
 
 
 # *** Globals ***


### PR DESCRIPTION
The Debian package gir1.2-appindicator3-0.1 exists in Debian
releases Stretch and Buster, but got dropped from Bullseye.
Ubuntu seems to contain both packages in current releases.

Debian:
[libappindicator](https://packages.debian.org/source/buster/libappindicator)
[libayatana-appindicator](https://packages.debian.org/source/sid/libayatana-appindicator)
[RM: libappindicator](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037)
[ITP: libayatana-appindicator](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863170)

Ubuntu:
[libappindicator](https://packages.ubuntu.com/source/impish/libappindicator)
[libayatana-appindicator](https://packages.ubuntu.com/source/impish/libayatana-appindicator)
