### PR TITLE
Image MAME CHD - Initial scaffolding.

### DIFF
--- a/libmirage/images/image-chd/CMakeLists.txt
+++ b/libmirage/images/image-chd/CMakeLists.txt
@@ -16,7 +16,8 @@ if(TRUE)
 
     # Dependencies
     pkg_check_modules(CHDR REQUIRED libchdr>=. IMPORTED_TARGET)
-    
+    target_link_libraries(${image_name} PUBLIC PkgConfig::CHDR)
+
     # Install
     install(TARGETS ${image_name} DESTINATION ${MIRAGE_PLUGIN_DIR})
 

--- a/libmirage/images/image-chd/CMakeLists.txt
+++ b/libmirage/images/image-chd/CMakeLists.txt
@@ -1,0 +1,38 @@
+set(image_short "chd")
+set(image_name "image-${image_short}")
+
+project(${image_name} LANGUAGES C)
+
+# Build
+if(TRUE)
+    add_library(${image_name} MODULE
+        parser.c
+        plugin.c
+    )
+    target_link_libraries(${image_name} PRIVATE mirage)
+
+    # Disable library prefix
+    set_target_properties(${image_name} PROPERTIES PREFIX "")
+
+    # Dependencies
+    pkg_check_modules(CHDR REQUIRED libchdr>=. IMPORTED_TARGET)
+    
+    # Install
+    install(TARGETS ${image_name} DESTINATION ${MIRAGE_PLUGIN_DIR})
+
+    # Install MIME type
+    intltool_merge("-x" ${CMAKE_SOURCE_DIR}/po ${PROJECT_SOURCE_DIR}/libmirage-${image_short}.xml.in libmirage-${image_short}.xml)
+
+    install(FILES ${PROJECT_BINARY_DIR}/libmirage-${image_short}.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages)
+    if(POST_INSTALL_HOOKS)
+        install(CODE "execute_process (COMMAND ${UPDATE_MIME_DATABASE_EXECUTABLE} ${CMAKE_INSTALL_FULL_DATADIR}/mime)")
+    endif()
+
+    # Add to list of enabled image formats
+    list(APPEND IMAGE_FORMATS_ENABLED ${image_short})
+    set(IMAGE_FORMATS_ENABLED ${IMAGE_FORMATS_ENABLED} PARENT_SCOPE)
+else()
+    # Add to list of disabled image formats
+    list(APPEND IMAGE_FORMATS_DISABLED ${image_short})
+    set(IMAGE_FORMATS_DISABLED ${IMAGE_FORMATS_DISABLED} PARENT_SCOPE)
+endif()

--- a/libmirage/images/image-chd/image-chd.h
+++ b/libmirage/images/image-chd/image-chd.h
@@ -1,0 +1,40 @@
+/*
+ *  libMirage: chd image
+ *  Copyright (C) 2011-2014 Rok Mandeljc
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __IMAGE_CHD_H__
+#define __IMAGE_CHD_H__
+
+#include "mirage/config.h"
+#include <mirage/mirage.h>
+
+#include <glib/gi18n-lib.h>
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <libchdr/chd.h>
+
+#include "parser.h"
+
+
+G_BEGIN_DECLS
+
+G_END_DECLS
+
+#endif /* __IMAGE_CHD_H__ */

--- a/libmirage/images/image-chd/libmirage-chd.xml.in
+++ b/libmirage/images/image-chd/libmirage-chd.xml.in
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/x-mame-chd">
+        <generic-icon name="application-x-executable"/>
+    
+        <_comment>MAME Compressed Hunk of Data</_comment>
+    
+        <glob pattern="*.chd"/>
+
+        <magic priority="50">
+            <match type="string" value="MComprHD" offset="0"/>
+        </magic>
+    </mime-type>
+</mime-info>

--- a/libmirage/images/image-chd/parser.c
+++ b/libmirage/images/image-chd/parser.c
@@ -45,7 +45,6 @@ static gboolean mirage_parser_chd_is_file_valid (MirageParserChd *self, MirageSt
 
     /* Set filenames */
     self->priv->chd_filename = mirage_stream_get_filename(stream);
-    mirage_disc_set_filename(self->priv->disc, self->priv->chd_filename);
 
     /* File must have .chd suffix */
     MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: verifying image file's suffix...\n%s\n", __debug__, self->priv->chd_filename);
@@ -116,6 +115,7 @@ static MirageDisc *mirage_parser_chd_load_image (MirageParser *_self, MirageStre
     /* Create disc */
     self->priv->disc = g_object_new(MIRAGE_TYPE_DISC, NULL);
     mirage_object_set_parent(MIRAGE_OBJECT(self->priv->disc), self);
+    mirage_disc_set_filename(self->priv->disc, self->priv->chd_filename);
 
     MIRAGE_DEBUG(self, MIRAGE_DEBUG_PARSER, "%s: CHD filename: %s\n", __debug__, self->priv->chd_filename);
 

--- a/libmirage/images/image-chd/parser.c
+++ b/libmirage/images/image-chd/parser.c
@@ -1,0 +1,188 @@
+/*
+ *  libMirage: chd image: parser
+ *  Copyright (C) 2011-2014 Rok Mandeljc
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "image-chd.h"
+
+#define __debug__ "CHD-Parser"
+
+
+/**********************************************************************\
+ *                          Private structure                         *
+\**********************************************************************/
+struct _MirageParserChdPrivate {
+    MirageDisc *disc;
+
+    const chd_header* header;
+    const gchar *chd_filename;
+
+    MirageSession *cur_session;
+    MirageTrack *cur_track;
+};
+
+
+static gboolean mirage_parser_chd_is_file_valid (MirageParserChd *self, MirageStream *stream, GError **error)
+{
+    chd_error err;
+    chd_file* file;
+    unsigned int totalbytes;
+    guint64 file_size;
+
+    /* Set filenames */
+    self->priv->chd_filename = mirage_stream_get_filename(stream);
+    mirage_disc_set_filename(self->priv->disc, self->priv->chd_filename);
+
+    /* File must have .chd suffix */
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: verifying image file's suffix...\n%s\n", __debug__, self->priv->chd_filename);
+    if (!mirage_helper_has_suffix(self->priv->chd_filename, ".chd")) {
+        MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: invalid suffix (not a *.chd file!)!\n", __debug__);
+        g_set_error(error, MIRAGE_ERROR, MIRAGE_ERROR_CANNOT_HANDLE, Q_("Parser cannot handle given image: invalid suffix!"));
+        return FALSE;
+    }
+
+    /* Opening image file for reading */
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: opening image file for reading... CHD_OPEN_READ=%d\n", __debug__, CHD_OPEN_READ);
+    
+    // Enter the abyss after this
+    return FALSE;
+    
+    err = chd_open(self->priv->chd_filename, CHD_OPEN_READ, NULL, &file);
+    if (err) {
+        MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: chd_open() error: %s\n", __debug__, chd_error_string(err));
+        g_set_error(error, MIRAGE_ERROR, MIRAGE_ERROR_CANNOT_HANDLE, Q_("Parser cannot handle given image: failed to open image!"));
+        return FALSE;
+    }
+
+     /* Retrieve chd header */
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: reading chd header...\n", __debug__);
+    self->priv->header = chd_get_header(file);
+    totalbytes = self->priv->header->hunkbytes * self->priv->header->totalhunks;
+    mirage_stream_seek(stream, 0, G_SEEK_END, NULL);
+    file_size = mirage_stream_tell(stream);
+
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: verifying file length:\n", __debug__);
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s:  expected size (based on header): %d \n", __debug__, totalbytes);
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s:  actual data file size: %" G_GINT64_MODIFIER "d\n", __debug__, file_size);
+
+    if (file_size == totalbytes) {
+        return TRUE;
+    }
+
+    /* Nope, can't load the file */
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: parser cannot handle given image: invalid data file size!\n", __debug__);
+    g_set_error(error, MIRAGE_ERROR, MIRAGE_ERROR_CANNOT_HANDLE, Q_("Parser cannot handle given image!"));
+    return FALSE;
+}
+
+
+/**********************************************************************\
+ *                MirageParser methods implementation               *
+\**********************************************************************/
+static MirageDisc *mirage_parser_chd_load_image (MirageParser *_self, MirageStream **streams, GError **error)
+{
+    MirageParserChd *self = MIRAGE_PARSER_CHD(_self);
+    gboolean succeeded = TRUE;
+    MirageStream *stream;
+
+    /* Check if file can be loaded */
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: checking if parser can handle given image...\n", __debug__);
+
+    stream = g_object_ref(streams[0]);
+
+    if (!mirage_parser_chd_is_file_valid(self, stream, error)) {
+        MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: parser cannot handle given image: invalid CHD file!\n", __debug__);
+        g_object_unref(stream);
+        return FALSE;
+    }
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_IMAGE_ID, "%s: parser can handle given image!\n", __debug__);
+
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_PARSER, "%s: parsing the image...\n", __debug__);
+
+    /* Create disc */
+    self->priv->disc = g_object_new(MIRAGE_TYPE_DISC, NULL);
+    mirage_object_set_parent(MIRAGE_OBJECT(self->priv->disc), self);
+
+    MIRAGE_DEBUG(self, MIRAGE_DEBUG_PARSER, "%s: CHD filename: %s\n", __debug__, self->priv->chd_filename);
+
+    // Lets get to here first then we can get creative.
+
+    /* Return disc */
+    if (succeeded) {
+        MIRAGE_DEBUG(self, MIRAGE_DEBUG_PARSER, "%s: parsing completed successfully\n\n", __debug__);
+        return self->priv->disc;
+    } else {
+        MIRAGE_DEBUG(self, MIRAGE_DEBUG_PARSER, "%s: parsing failed!\n\n", __debug__);
+        g_object_unref(self->priv->disc);
+        return NULL;
+    }
+}
+
+
+/**********************************************************************\
+ *                             Object init                            *
+\**********************************************************************/
+G_DEFINE_DYNAMIC_TYPE_EXTENDED(MirageParserChd,
+                               mirage_parser_chd,
+                               MIRAGE_TYPE_PARSER,
+                               0,
+                               G_ADD_PRIVATE_DYNAMIC(MirageParserChd))
+
+void mirage_parser_chd_type_register (GTypeModule *type_module)
+{
+    return mirage_parser_chd_register_type(type_module);
+}
+
+
+static void mirage_parser_chd_init (MirageParserChd *self)
+{
+    self->priv = mirage_parser_chd_get_instance_private(self);
+
+    mirage_parser_generate_info(MIRAGE_PARSER(self),
+        "PARSER-CHD",
+        Q_("CHD Image Parser"),
+        1,
+        Q_("chd images (*.chd)"), "application/x-mame-chd"
+    );
+}
+
+static void mirage_parser_chd_dispose (GObject *gobject)
+{
+    /* Chain up to the parent class */
+    return G_OBJECT_CLASS(mirage_parser_chd_parent_class)->dispose(gobject);
+}
+
+static void mirage_parser_chd_finalize (GObject *gobject)
+{
+    /* Chain up to the parent class */
+    return G_OBJECT_CLASS(mirage_parser_chd_parent_class)->finalize(gobject);
+}
+
+static void mirage_parser_chd_class_init (MirageParserChdClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+    MirageParserClass *parser_class = MIRAGE_PARSER_CLASS(klass);
+
+    gobject_class->dispose = mirage_parser_chd_dispose;
+    gobject_class->finalize = mirage_parser_chd_finalize;
+
+    parser_class->load_image = mirage_parser_chd_load_image;
+}
+
+static void mirage_parser_chd_class_finalize (MirageParserChdClass *klass G_GNUC_UNUSED)
+{
+}

--- a/libmirage/images/image-chd/parser.h
+++ b/libmirage/images/image-chd/parser.h
@@ -50,6 +50,7 @@ struct _MirageParserChdClass
 /* Used by MIRAGE_TYPE_PARSER_CHD */
 GType mirage_parser_chd_get_type (void);
 void mirage_parser_chd_type_register (GTypeModule *type_module);
+const char *_byte_array_to_hex_string(const UINT8 *pin, const UINT8 size);
 
 G_END_DECLS
 

--- a/libmirage/images/image-chd/parser.h
+++ b/libmirage/images/image-chd/parser.h
@@ -1,0 +1,56 @@
+/*
+ *  libMirage: chd image: parser
+ *  Copyright (C) 2011-2014 Rok Mandeljc
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __IMAGE_CHD_PARSER_H__
+#define __IMAGE_CHD_PARSER_H__
+
+
+G_BEGIN_DECLS
+
+#define MIRAGE_TYPE_PARSER_CHD            (mirage_parser_chd_get_type())
+#define MIRAGE_PARSER_CHD(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), MIRAGE_TYPE_PARSER_CHD, MirageParserChd))
+#define MIRAGE_PARSER_CHD_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), MIRAGE_TYPE_PARSER_CHD, MirageParserChdClass))
+#define MIRAGE_IS_PARSER_CHD(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), MIRAGE_TYPE_PARSER_CHD))
+#define MIRAGE_IS_PARSER_CHD_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), MIRAGE_TYPE_PARSER_CHD))
+#define MIRAGE_PARSER_CHD_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj), MIRAGE_TYPE_PARSER_CHD, MirageParserChdClass))
+
+typedef struct _MirageParserChd        MirageParserChd;
+typedef struct _MirageParserChdClass   MirageParserChdClass;
+typedef struct _MirageParserChdPrivate MirageParserChdPrivate;
+
+struct _MirageParserChd
+{
+    MirageParser parent_instance;
+
+    /*< private >*/
+    MirageParserChdPrivate *priv;
+};
+
+struct _MirageParserChdClass
+{
+    MirageParserClass parent_class;
+};
+
+/* Used by MIRAGE_TYPE_PARSER_CHD */
+GType mirage_parser_chd_get_type (void);
+void mirage_parser_chd_type_register (GTypeModule *type_module);
+
+G_END_DECLS
+
+#endif /* __IMAGE_CHD_PARSER_H__ */

--- a/libmirage/images/image-chd/plugin.c
+++ b/libmirage/images/image-chd/plugin.c
@@ -1,0 +1,35 @@
+/*
+ *  libMirage: chd image: plugin exports
+ *  Copyright (C) 2011-2014 Rok Mandeljc
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "image-chd.h"
+
+G_MODULE_EXPORT void mirage_plugin_load_plugin (MiragePlugin *plugin);
+G_MODULE_EXPORT void mirage_plugin_unload_plugin (MiragePlugin *plugin);
+
+G_MODULE_EXPORT guint mirage_plugin_soversion_major = MIRAGE_SOVERSION_MAJOR;
+G_MODULE_EXPORT guint mirage_plugin_soversion_minor = MIRAGE_SOVERSION_MINOR;
+
+G_MODULE_EXPORT void mirage_plugin_load_plugin (MiragePlugin *plugin)
+{
+    mirage_parser_chd_type_register(G_TYPE_MODULE(plugin));
+}
+
+G_MODULE_EXPORT void mirage_plugin_unload_plugin (MiragePlugin *plugin G_GNUC_UNUSED)
+{
+}

--- a/libmirage/po/POTFILES.in
+++ b/libmirage/po/POTFILES.in
@@ -22,6 +22,8 @@ images/image-ccd/libmirage-ccd.xml.in
 images/image-ccd/parser.c
 images/image-cdi/libmirage-cdi.xml.in
 images/image-cdi/parser.c
+images/image-chd/libmirage-chd.xml.in
+images/image-chd/parser.c
 images/image-cif/libmirage-cif.xml.in
 images/image-cif/parser.c
 images/image-cue/parser.c


### PR DESCRIPTION
As per #16 introducing the feature requirement.

Was actually hoping to make more progress but for some reason as soon as you attempt to open the image it fades into the abyss and no debug information comes back.

It basically does the same as the [benchmark test](/rtissera/libchdr/blob/master/tests/benchmark.c), which can be used to test a working image. We just want to retrieve the headers as part of the initial support for the format assertion... 

```C
  err = chd_open(argv[1], CHD_OPEN_READ, NULL, &file);
  if (err)
  {
    printf("\nchd_open() error: %s", chd_error_string(err));
    return 0;
  }
  header = chd_get_header(file);
  totalbytes = header->hunkbytes * header->totalhunks;
```
...which seems too much to ask for at this point.

Perhaps someone else can have more luck with this, hopefully it helps.
 
 