### PR TITLE
Require device number when removing device

### DIFF
--- a/cdemu-client/man/cdemu.1
+++ b/cdemu-client/man/cdemu.1
@@ -79,8 +79,9 @@ Displays devices' status
 .B add-device
 Creates another virtual device
 .TP
-.B remove-device
-Removes the last virtual device
+.B remove-device <device>
+Removes the virtual device; \fBdevice\fR is the number of the desired device, or \fIall\fR.
+.TP
 .TP
 .B device-mapping
 Displays device mapping information

--- a/cdemu-client/po/de.po
+++ b/cdemu-client/po/de.po
@@ -623,7 +623,7 @@ msgid "Device added successfully."
 msgstr ""
 
 #: ../src/cdemu:1174
-msgid "removes the last virtual device"
+msgid "removes the virtual device"
 msgstr ""
 
 #: ../src/cdemu:1183

--- a/cdemu-client/po/fr.po
+++ b/cdemu-client/po/fr.po
@@ -646,7 +646,7 @@ msgid "Device added successfully."
 msgstr ""
 
 #: ../src/cdemu:1174
-msgid "removes the last virtual device"
+msgid "removes the virtual device"
 msgstr ""
 
 #: ../src/cdemu:1183

--- a/cdemu-client/po/no.po
+++ b/cdemu-client/po/no.po
@@ -624,8 +624,8 @@ msgid "Device added successfully."
 msgstr "Enhet lagt til."
 
 #: ../src/cdemu:1174
-msgid "removes the last virtual device"
-msgstr "fjerner den siste virtuelle enheten"
+msgid "removes the virtual device"
+msgstr "fjerner den virtuelle enheten"
 
 #: ../src/cdemu:1183
 #, fuzzy, c-format

--- a/cdemu-client/po/pl.po
+++ b/cdemu-client/po/pl.po
@@ -615,7 +615,7 @@ msgid "Device added successfully."
 msgstr ""
 
 #: ../src/cdemu:1174
-msgid "removes the last virtual device"
+msgid "removes the virtual device"
 msgstr ""
 
 #: ../src/cdemu:1183

--- a/cdemu-client/po/ru.po
+++ b/cdemu-client/po/ru.po
@@ -608,8 +608,8 @@ msgid "Device added successfully."
 msgstr "Накопитель добавлен успешно."
 
 #: ../src/cdemu:1174
-msgid "removes the last virtual device"
-msgstr "удаляет последний виртуальный накопитель"
+msgid "removes the virtual device"
+msgstr "удаляет виртуальный накопитель"
 
 #: ../src/cdemu:1183
 #, c-format

--- a/cdemu-client/po/sl.po
+++ b/cdemu-client/po/sl.po
@@ -605,8 +605,8 @@ msgid "Device added successfully."
 msgstr "Dodajanje naprave je uspelo."
 
 #: ../src/cdemu:1174
-msgid "removes the last virtual device"
-msgstr "odstrani zadnjo navidezno napravo"
+msgid "removes the virtual device"
+msgstr "odstrani navidezno napravo"
 
 #: ../src/cdemu:1183
 #, c-format

--- a/cdemu-client/po/sv.po
+++ b/cdemu-client/po/sv.po
@@ -633,8 +633,8 @@ msgid "Device added successfully."
 msgstr "Enheten lades till."
 
 #: ../src/cdemu:1174
-msgid "removes the last virtual device"
-msgstr "tar bort den sista virtuella enheten"
+msgid "removes the virtual device"
+msgstr "tar bort den virtuella enheten"
 
 #: ../src/cdemu:1183
 #, c-format

--- a/cdemu-client/src/cdemu
+++ b/cdemu-client/src/cdemu
@@ -1371,16 +1371,34 @@ class cmd_remove_device (object):
     def __init__ (self, subparsers):
         name = "remove-device"
         description_msg = _("")
-        help_msg = _("removes the last virtual device")
+        help_msg = _("removes the virtual device")
 
         parser = subparsers.add_parser(name, description=description_msg, help=help_msg, formatter_class=argparse.ArgumentDefaultsHelpFormatter, argument_default=argparse.SUPPRESS)
         parser.set_defaults(command_function=self)
 
+        parser.add_argument("device", type=str, help=_("device"))
+
     def __call__ (self, proxy, arguments):
-        try:
-            proxy.RemoveDevice()
-        except GLib.Error as e:
-            raise CDEmuError(_("Failed to remove device: %s") % (e))
+        if arguments.device == "all":
+            try:
+                num_devices = proxy.GetNumberOfDevices()
+            except GLib.Error as e:
+                raise CDEmuError(_("Failed to get number of devices: %s") % (e))
+
+            for device in range(num_devices):
+                try:
+                    proxy.RemoveDevice(device)
+                except GLib.Error as e:
+                    print_warning(_("Failed to remove device %i: %s") % (device, e))
+                    continue
+        else:
+            try:
+                device = int(arguments.device)
+                proxy.RemoveDevice(device)
+            except GLib.Error as e:
+                raise CDEmuError(_("Failed to remove device %i: %s") % (device, e))
+            except ValueError:
+                raise CDEmuError(_("String '%s' is not a number") % (arguments.device))
 
         print(_("Device removed successfully."))
 
@@ -1521,8 +1539,8 @@ class CDEmuDaemonProxy ():
     def AddDevice (self):
         return self.proxy.AddDevice()
 
-    def RemoveDevice (self):
-        return self.proxy.RemoveDevice()
+    def RemoveDevice (self, device_number):
+        return self.proxy.RemoveDevice('(i)', device_number)
 
 
 ########################################################################

--- a/cdemu-daemon/README
+++ b/cdemu-daemon/README
@@ -445,7 +445,7 @@ control the daemon:
     - Creates additional virtual device
 
 * RemoveDevice ()
-    - Removes the last-created virtual device
+    - Removes the virtual device
 
 6.3. Signals
 ~~~~~~~~~~~~

--- a/cdemu-daemon/src/daemon-dbus.c
+++ b/cdemu-daemon/src/daemon-dbus.c
@@ -356,7 +356,9 @@ static void cdemu_daemon_dbus_handle_method_call (GDBusConnection *connection G_
         }
     } else if (!g_strcmp0(method_name, "RemoveDevice")) {
         /* *** RemoveDevice *** */
-        succeeded = cdemu_daemon_remove_device(self);
+        gint device_number;
+        g_variant_get(parameters, "(i)", &device_number);
+        succeeded = cdemu_daemon_remove_device(self, device_number);
         if (!succeeded) {
             g_set_error(&error, CDEMU_ERROR, CDEMU_ERROR_DAEMON_ERROR, Q_("Failed to remove device!"));
         }
@@ -653,7 +655,9 @@ static const gchar introspection_xml[] =
 
     "        <!-- Device management methods -->"
     "        <method name='AddDevice' />"
-    "        <method name='RemoveDevice' />"
+    "        <method name='RemoveDevice'>"
+    "            <arg name='device_number' type='i' direction='in'/>"
+    "        </method>"
 
     "        <!-- Notification signals -->"
     "        <signal name='DeviceStatusChanged'>"

--- a/cdemu-daemon/src/daemon-private.h
+++ b/cdemu-daemon/src/daemon-private.h
@@ -43,7 +43,7 @@ struct _CdemuDaemonPrivate
 
 /* Device management */
 gboolean cdemu_daemon_add_device (CdemuDaemon *self);
-gboolean cdemu_daemon_remove_device (CdemuDaemon *self);
+gboolean cdemu_daemon_remove_device (CdemuDaemon *self, gint device_number);
 CdemuDevice *cdemu_daemon_get_device (CdemuDaemon *self, gint device_number, GError **error);
 
 /* Daemon's D-BUS API */

--- a/cdemu-daemon/src/daemon.c
+++ b/cdemu-daemon/src/daemon.c
@@ -194,10 +194,10 @@ gboolean cdemu_daemon_add_device (CdemuDaemon *self)
     return TRUE;
 }
 
-gboolean cdemu_daemon_remove_device (CdemuDaemon *self)
+gboolean cdemu_daemon_remove_device (CdemuDaemon *self, gint device_number)
 {
     /* Get last device entry */
-    GList *entry = g_list_last(self->priv->devices);
+    GList *entry = g_list_nth(self->priv->devices, device_number);
     if (!entry) {
         return FALSE;
     }


### PR DESCRIPTION
- **Previous:** device removal removed the last device
- **Changed:** device removal requires specifying the device number (or "all" when using the CLI)

**Why?**
I'm using cdemu in a wrapper script which creates a new device, mounts an image to the new device, and mounts any partitions on the cd. When I'm finished with the mounted image, I'd like to automatically delete the device that my script initially created. However, the device my script initially created may no longer be the last cdemu device.

Changing cdemu's device removal to allow specifying the device would resolve this for me.

The behavior of the CLI's `remove-device` command is now consistent with the CLI's `unload` command.

---

I understand that my change is breaking as the `remove-device` command now requires an argument. Let me know if this is a problem and I'll add functionality to default to removing the last device.

---

It's also worth mentioning that device numbers are not persistent and can change when removing a device. Ex. removing device `2` causes devices `3` and `4` to become `2` and `3` respectively.
```
$ cdemu status
Devices' status:
DEV   LOADED     FILENAME
0     True       /home/ar/multisession/jewel_case_carnivores/dump_240522_145336_sr1.cue
1     True       /home/ar/multisession/jewel_case_deusex_goty-soundtrack/dump_240514_155815_sr0.cue
2     True       /home/ar/multisession/jewel_case_duke_nukem_music_to_score_by/dump_240515_224807_sr0.cue
3     True       /home/ar/multisession/marathon_blue/dump_240511_235714_sr0.cue
4     True       /home/ar/multisession/smallbox_the_movies_premiere_edition-bonus_disc/dump_240528_163907_sr2.cue
$ cdemu remove-device 2
Device removed successfully.
$ cdemu status
Devices' status:
DEV   LOADED     FILENAME
0     True       /home/ar/multisession/jewel_case_carnivores/dump_240522_145336_sr1.cue
1     True       /home/ar/multisession/jewel_case_deusex_goty-soundtrack/dump_240514_155815_sr0.cue
2     True       /home/ar/multisession/marathon_blue/dump_240511_235714_sr0.cue
3     True       /home/ar/multisession/smallbox_the_movies_premiere_edition-bonus_disc/dump_240528_163907_sr2.cue
```
