### PR TITLE
Fix navigationBar for matplotlib 3.5+

### DIFF
--- a/image-analyzer/src/image-analyzer
+++ b/image-analyzer/src/image-analyzer
@@ -82,6 +82,10 @@ if sys.platform == "linux" or sys.platform == "linux2":
         pass
 
 
+# matplotlib version
+mpl_version = getattr(matplotlib, '__version_info__', None)
+
+
 ########################################################################
 #                           Helper functions                           #
 ########################################################################
@@ -574,7 +578,6 @@ class DiscTopologyWindow (Gtk.Window):
         # Matplotlib toolbar - in versions < 3.6.0, NavigationToolbar
         # accepted two arguments, canvas and window. In 3.6.0, the
         # second argument was deprecated, and removed in 3.8.0.
-        mpl_version = getattr(matplotlib, '__version_info__', None)
         if mpl_version is None or mpl_version < (3, 6):
             toolbar = NavigationToolbar(canvas, self)
         else:
@@ -629,11 +632,13 @@ class DiscTopologyWindow (Gtk.Window):
         axes.plot(sector_address, sector_density, color='red', linewidth=2.0)
         axes.set_facecolor('#ffffc7')
 
-        mpl_version_b = getattr(matplotlib, '__version_info__', None)
-        if mpl_version_b is None or mpl_version_b < (3, 5):
-            axes.grid(b=True, which='both', color='black',linestyle=':')
+        # As of matplotlib 3.5, the argument "b" of "grid()" has been
+        # renamed to "visible".
+        # See: https://github.com/matplotlib/matplotlib/issues/25267
+        if mpl_version is None or mpl_version < (3, 5):
+            axes.grid(b=True, which='both', color='black', linestyle=':')
         else:
-            axes.grid(visible=True, which='both', color='black',linestyle=':')
+            axes.grid(visible=True, which='both', color='black', linestyle=':')
         axes.set_xlim(sector_address[0], sector_address[-1])
 
         axes.set_xlabel(_("Sector address"))


### PR DESCRIPTION
As described in https://github.com/matplotlib/matplotlib/issues/25267 , "The first parameter of Axes.grid and Axis.grid has been renamed to visible. The parameter was previously named b. This deprecation only matters if that parameter was passed using a keyword argument, e.g. grid(b=False).". As a result, when using matplotlib 3.5 or higher, which covers any version released within the last 4 years, the navigationBar in the topology viewer window will be greyed out and unusable, making it impossible to zoom in or perform other functions. This adds a matplotlib version check similar to the existing one for another set of NavigationToolbar-related function arguments in order to handle this issue.