### PR TITLE
daemon: fix use-after-free in READ DISC INFORMATION

### DIFF
--- a/cdemu-daemon/src/device-commands.c
+++ b/cdemu-daemon/src/device-commands.c
@@ -1373,6 +1373,7 @@ static gboolean command_read_disc_information (CdemuDevice *self, const guint8 *
                 /* Disc type is determined from first session, as per INF8090 */
                 disc_type = map_session_type(mirage_session_get_session_type(session));
                 g_object_unref(session);
+                session = NULL;
             } else if (self->priv->recordable_disc && self->priv->open_session) {
                 /* If the only session on disc is incomplete, get disc type from it */
                 disc_type = map_session_type(mirage_session_get_session_type(self->priv->open_session));


### PR DESCRIPTION
After closing a session with multisession enabled, the 'session' variable from the first-session disc_type lookup was freed but not NULLed.  When the last-session block took the recordable && !disc_closed && !open_session path (i.e. between sessions on a multi-session disc), it skipped reassigning 'session', leaving a dangling pointer.  The subsequent if(session) block then dereferenced freed memory, causing a SIGSEGV.

Fix: NULL out session after the first g_object_unref.